### PR TITLE
Clean up compilation warnings and errors

### DIFF
--- a/source/wamped/SocketPosix.cpp
+++ b/source/wamped/SocketPosix.cpp
@@ -16,7 +16,7 @@
 #include "SocketPosix.h"
 #include <netdb.h>
 #include <stdlib.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <cstring>
 #include <unistd.h>
 

--- a/source/wamped/Wamp.cpp
+++ b/source/wamped/Wamp.cpp
@@ -57,10 +57,17 @@ void Wamp::connect(std::function<void()> onJoin, std::function<void()> onError) 
     connect (onJoin);
 }
 
+#ifdef DEBUG_WAMP
 void Wamp::loggedSend(const std::string &msg) {
     LOG("Sending " << msg << ": " << mp.getJson());
     this->transport.sendMessage(mp.getData(), mp.getUsedBuffer());
 }
+#else
+void Wamp::loggedSend(const std::string &) {
+    this->transport.sendMessage(mp.getData(), mp.getUsedBuffer());
+}
+#endif
+
 
 void Wamp::hello(string realm) {
     mp.clear();

--- a/source/wamped/WampTransportRaw.cpp
+++ b/source/wamped/WampTransportRaw.cpp
@@ -124,9 +124,7 @@ void WampTransportRaw::sendMessage(char* buffer, size_t size) {
 
 void WampTransportRaw::decode(char *buffer, int size) {
     char prefixMSG[4];
-    unsigned long int max_len_send;
     unsigned long int msgSize = 0;
-    int serializer_type;
 
     //LOG(DEBUG) << "Decoding Size:" << size << "Payload:" << toHexString((const unsigned char *) buffer, size);
 
@@ -143,10 +141,8 @@ void WampTransportRaw::decode(char *buffer, int size) {
                         }
                         break;
                     case 1: //Re ad max len and streaming size
-                        max_len_send = (unsigned long int) pow(2, (9 + ((unsigned char) buffer[i] >> 4)));
-                        LOG("Max bytes per message " << max_len_send);
-                        serializer_type = buffer[i] & 0x0f;
-                        LOG("Serializer  " << serializer_type);
+                        LOG("Max bytes per message " << (unsigned long int) pow(2, (9 + ((unsigned char) buffer[i] >> 4))));
+                        LOG("Serializer  " << buffer[i] & 0x0f);
                         byteNumber++;
                         break;
                     case 2: // First reserved byte


### PR DESCRIPTION
I was building wamped in an environment where `-Werror` was set, and was affected by a few simple compiler warnings:

- `unused-parameter` error when logging is disabled
  - I removed the intermediate variables `max_len_send` and `serializer_type` so that the expressions only evaluate when logging is enabled
  - I changed the definition of `Wamp::loggedSend` to not use its parameter when logging is disabled
- redirected header error on `#include <sys/errno.h>`, it should just be `#include <errno.h>`

This change fixes these issues and allows for stricter compilation :)